### PR TITLE
Make mobile graph viewer full screen, plus change button position

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
               <Route index element={<MainPage />}/>
               <Route path="models" element={<ModelsPage />}/>
               <Route path="models/:id" element={<ModelsDetailPage />}/>
-              <Route path="models/:id/modelView" element={<ModelViewer />}/>
+              <Route path="models/:id/modelView" element={<div className="fullscreen"><ModelViewer /></div>}/>
           </Route>
       </Routes>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -309,6 +309,24 @@ h4 {
   border: 2px solid black;
 }
 
+.fullscreen > .modelViewerContainer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: auto;
+  height: auto;
+  margin: 0;
+}
+
+.fullscreen > .modelViewerContainer > .modelView {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+  border: none;
+}
+
 @media only screen and (max-width: 1023px) {
   h1 {
     font-size: 2.7em;
@@ -502,10 +520,10 @@ h4 {
   }
 
   .mobileViewerComponent {
-    display: unset;
+    display: block;
   }
 
   .newTab_button {
-    margin-bottom: 2rem;
+    margin-bottom: 1rem;
   }
 }


### PR DESCRIPTION
(1) In my browser, I had the "open in new tab" touching the "back to model page" button. This PR should fix that and ensure there is a margin between the two buttons.

(2) It is not necessary to have the border/margin for model viewer on mobile since we want to maximize usable space. When opened as a separate page, the model viewer is opened inside a "fullscreen" tag which ensures the whole component always takes the whole screen.